### PR TITLE
feat: add algolia search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -124,6 +124,13 @@ const config = {
         persistence: "localStorage",
         autocapture: false,
       },
+      algolia: {
+        appId: "O4JS38E98E",
+        apiKey: "4ed94b4d8517278004c4fd8b4f5bf659", // Public API key: it is safe to commit it
+        indexName: "worldcoin",
+        contextualSearch: true,
+        searchPagePath: "search",
+      },
     }),
 };
 


### PR DESCRIPTION
We got approved to Algolia's DocSearch as World ID is a fully open source project. This adds seamless search functionality to the docs.

<img width="585" alt="" src="https://user-images.githubusercontent.com/5864173/172626109-37eef12c-0055-4fa0-aca0-e7bb58ee513a.png">

