### PR TITLE
refactor: improve paddings

### DIFF
--- a/src/Layout/Navbar/Section/index.tsx
+++ b/src/Layout/Navbar/Section/index.tsx
@@ -33,11 +33,11 @@ export const Section = memo(function Section(
         )}
 
         {props.href ? (
-          <Link href={props.href} className="text-20 font-semibold">
+          <Link href={props.href} className="truncate text-20 font-semibold">
             {props.title}
           </Link>
         ) : (
-          <p className="text-20 font-semibold">{props.title}</p>
+          <p className="truncate text-20 font-semibold">{props.title}</p>
         )}
       </div>
 

--- a/src/Layout/TableOfContent/Items/index.tsx
+++ b/src/Layout/TableOfContent/Items/index.tsx
@@ -34,7 +34,9 @@ export const Items = memo(function Items(props: {
           style={{ paddingLeft: `${(props.level || 0) * 24}px` }}
           key={item.id}
         >
-          <Link href={`#${item.id}`}>{item.title}</Link>
+          <Link className="truncate" href={`#${item.id}`}>
+            {item.title}
+          </Link>
 
           <Items
             items={item.children}

--- a/src/Layout/index.tsx
+++ b/src/Layout/index.tsx
@@ -61,11 +61,14 @@ export const Layout = memo(function Layout(props: {
             }
           )}
         >
-          <aside className="sticky top-20 hidden border-r border-858494/20 pr-16 lg:block">
+          <aside className="sticky top-20 hidden border-r border-858494/20 lg:block lg:pr-4 2xl:pr-16">
             <Navbar items={navItems} />
           </aside>
 
-          <main ref={mainRef} className="max-w-full overflow-hidden lg:px-16">
+          <main
+            ref={mainRef}
+            className="max-w-full overflow-hidden lg:min-w-[650px] lg:px-8 2xl:px-16"
+          >
             <article>
               {(props.title || section) && (
                 <header className="mb-3">
@@ -139,7 +142,7 @@ export const Layout = memo(function Layout(props: {
             </dl>
           </main>
 
-          <aside className="sticky top-20 hidden gap-y-9 pl-16 lg:grid">
+          <aside className="sticky top-20 hidden gap-y-9 lg:grid lg:pl-8 2xl:pl-16">
             <TableOfContent items={props.tableOfContents} />
           </aside>
         </div>

--- a/src/common/helpers/styles.ts
+++ b/src/common/helpers/styles.ts
@@ -1,5 +1,6 @@
 export const styles = {
-  screenPadding: 'px-4 md:px-8 lg:px-16',
+  screenPadding:
+    'px-4 md:px-8 lg:px-8 xl:px-16 2xl:px-[calc((100vw-1540px)/2)]',
   gradient: 'bg-gradient-to-r from-fff0ed to-edecfc',
   textGradient:
     'text-transparent bg-clip-text bg-gradient-to-r from-fff0ed to-edecfc',


### PR DESCRIPTION
Closing [WID-130](https://linear.app/worldcoin/issue/WID-130/on-narrower-screens-the-table-of-contents-should-be-compress-or)

- Update paddings 
- Add min width to main element on >lg size screens

---

https://user-images.githubusercontent.com/89008845/193265344-24eb2b91-f2c4-4faa-a576-8df2e44b2a7f.mp4