### PR TITLE
style: fix hover state

### DIFF
--- a/src/Layout/Navbar/Section/index.tsx
+++ b/src/Layout/Navbar/Section/index.tsx
@@ -19,7 +19,7 @@ export const Section = memo(function Section(
   return (
     <div className={props.className}>
       <div
-        className="uppercase tracking-wide text-14 font-medium leading-4"
+        className="ml-4 uppercase tracking-wide text-14 font-medium leading-4"
       >
         {props.href ? (
           <Link href={props.href} className="truncate">
@@ -31,7 +31,7 @@ export const Section = memo(function Section(
       </div>
 
       {props.items?.length && (
-        <div className="mt-2 grid text-16 leading-5">
+        <div className="mt-4 grid text-16 leading-5">
           {props.items.map((item, id) => (
             <Link
               key={`${slugify(item.title)}-${id}`}
@@ -40,7 +40,7 @@ export const Section = memo(function Section(
                 'relative min-w-[260px] cursor-pointer select-none py-2 px-4 rounded-lg transition-colors duration-300',
                 //'before:absolute before:top-1/2 before:left-0 before:w-1 before:h-1 before:rounded-full before:bg-current before:-translate-y-1/2',
                 {
-                  'text-neutral-400 dark:text-neutral-500 hover:text-neutral-500 hover:dark:text-neutral-400 hover:bg-neutral-50 hover:dark:bg-neutral-700/40': !isCurrent(item.href),
+                  'text-neutral-400 dark:text-neutral-500 hover:text-neutral-500 hover:dark:text-neutral-400 hover:bg-neutral-100 hover:dark:bg-neutral-700/40': !isCurrent(item.href),
                   'text-neutral-0 dark:text-000000 bg-neutral-900 dark:bg-neutral-0': isCurrent(item.href),
                 }
               )}

--- a/src/Layout/Prose/index.tsx
+++ b/src/Layout/Prose/index.tsx
@@ -22,7 +22,7 @@ export function Prose({
         // lead
         'prose-lead:text-slate-500 dark:prose-lead:text-slate-400',
         // links
-        'prose-a:font-normal prose-a:text-indigo-500 prose-a:[text-decoration:_none]',
+        'prose-a:font-normal prose-a:text-indigo-500 prose-a:[text-decoration:_none] hover:prose-a:opacity-70',
         // pre
         'prose-pre:rounded-lg prose-pre:bg-transparent',
         // hr

--- a/src/Layout/TableOfContent/Items/index.tsx
+++ b/src/Layout/TableOfContent/Items/index.tsx
@@ -27,15 +27,20 @@ export const Items = memo(function Items(props: {
     <Fragment>
       {props.items.map((item) => (
         <div
-          className={cn('grid gap-y-6', {
-            'text-black/40 dark:text-70868f': !isActive(item),
-            [`${cn('bg-8e87ff', styles.darkTextGradient)}`]: isActive(item),
-          })}
-          style={{ paddingLeft: `${(props.level || 0) * 24}px` }}
+          className="grid transition-colors duration-300"
           key={item.id}
         >
-          <Link className="truncate" href={`#${item.id}`}>
-            {item.title}
+          <Link
+            className={cn("px-4 py-2 rounded-lg truncate leading-5 transition-colors duration-300", {
+              "text-neutral-400 dark:text-neutral-500 hover:text-neutral-500 hover:dark:text-neutral-400 hover:bg-neutral-100 hover:dark:bg-neutral-700/40": !isActive(item),
+            })}
+            href={`#${item.id}`}
+          >
+            <span
+              style={{ paddingLeft: `${(props.level || 0) * 24}px` }}
+            >
+              {item.title}
+            </span>
           </Link>
 
           <Items

--- a/src/Layout/TableOfContent/index.tsx
+++ b/src/Layout/TableOfContent/index.tsx
@@ -39,11 +39,11 @@ export const TableOfContent = memo(function TableOfContent(props: {
 
   return (
     <Fragment>
-      <span className="uppercase tracking-wide text-14 text-191c20 dark:text-ffffff font-medium leading-4">
+      <span className="ml-4 uppercase tracking-wide text-14 text-191c20 dark:text-ffffff font-medium leading-4">
         On this page
       </span>
 
-      <nav className="grid gap-y-6">
+      <nav className="grid">
         <Items items={props.items} activeItem={activeItem} />
       </nav>
     </Fragment>

--- a/src/Layout/index.tsx
+++ b/src/Layout/index.tsx
@@ -137,7 +137,7 @@ export const Layout = memo(function Layout(props: {
             </dl>
           </main>
 
-          <aside className="sticky top-20 hidden gap-y-6 lg:grid lg:pl-8 2xl:pl-16">
+          <aside className="sticky top-20 hidden gap-y-4 lg:grid lg:pl-8 2xl:pl-16">
             <TableOfContent items={props.tableOfContents} />
           </aside>
         </div>


### PR DESCRIPTION
[WID-264](https://linear.app/worldcoin/issue/WID-264/fix-hover-state-on-light-mode)
- added a hovered state to the links
- increased the background contrast of the hovered links in the left and right menus a bit
- corrected right menu according to Figma

https://user-images.githubusercontent.com/104859710/224799267-0d38ccd1-87ef-4504-ba4a-2b2c397bb852.mp4

