### PR TITLE
fix: sitemap build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"private": true,
 	"scripts": {
 		"dev": "next dev",
-		"build": "next build",
-		"postbuild": "next-sitemap",
+		"build": "next build && pnpm sitemap",
+		"sitemap": "next-sitemap",
 		"start": "next start",
 		"lint": "next lint",
 		"typecheck": "tsc",


### PR DESCRIPTION
pnpm requires a `.npmrc` config file to enable automatic postbuild, this seems cleaner.