### PR TITLE
fix: use proper api base URL in sign in reference

### DIFF
--- a/src/pages/api-docs/sign-in-reference.mdx
+++ b/src/pages/api-docs/sign-in-reference.mdx
@@ -92,7 +92,7 @@ Registers a new application for use with Sign In with World ID.
     <CodeGroup title="Request" tag="POST" label="/register">
 
     ```bash {{ title: 'cURL' }}
-    curl -X POST https://developer.worldcoin.org/register \
+    curl -X POST https://id.worldcoin.org/register \
         -H "Content-Type: application/json" \
         -d '{
             "client_name": "Example Application",


### PR DESCRIPTION
updates the example cURL request for the /register endpoint to use the proper id.worldcoin.org base url