### PR TITLE
fix: try page scope

### DIFF
--- a/src/pages/try.tsx
+++ b/src/pages/try.tsx
@@ -288,7 +288,7 @@ const Try = (): JSX.Element => {
 		const baseUrl = new URL(`${process.env.NEXT_PUBLIC_SIGN_IN_WITH_WORLDCOIN_ENDPOINT}/authorize`)
 		baseUrl.searchParams.append('redirect_uri', `${process.env.NEXT_PUBLIC_APP_URL}/try-callback`)
 		baseUrl.searchParams.append('response_type', 'token')
-		baseUrl.searchParams.append('scope', signInScopes.join(' '))
+		baseUrl.searchParams.append('scope', ['openid', ...signInScopes].join(' '))
 
 		baseUrl.searchParams.append(
 			'client_id',


### PR DESCRIPTION
- Add `openid` scope because it is required now in /authorize endpoint. We can see it in the [yup schema](https://github.com/worldcoin/world-id-sign-in/blob/dbaf28ed7c1a8c50af903179636de63ac3bcf549/src/app/authorize/route.ts#L52-L55)