### PR TITLE
Update oidc explainer link

### DIFF
--- a/src/pages/id/sign-in.mdx
+++ b/src/pages/id/sign-in.mdx
@@ -35,7 +35,7 @@ World ID can be used as an authentication mechanism. Some helpful resources for 
     </TabItem>
     <TabItem label="Custom Authentication Engines">
       <Note type="warning">
-        If you don't have an authentication engine, you can implement OIDC flows yourself. See the [OIDC Explainer](/further-reading/oidc-explainer) and [Sign In Reference](/reference/sign-in) for details.
+        If you don't have an authentication engine, you can implement OIDC flows yourself. See the [OIDC Explainer](/further-reading/oidc) and [Sign In Reference](/reference/sign-in) for details.
       </Note>
 
       Configure your OIDC authentication engine to use World ID as an Identity Provider (IdP), you will need the following information:


### PR DESCRIPTION
Looks like this link wasn't changed when updating urls.

That's the page it's linking to: https://github.com/worldcoin/world-id-docs/blob/main/src/pages/further-reading/oidc.mdx