### PR TITLE
fix: remove "internal use only"

### DIFF
--- a/src/pages/further-reading/protocol-internals.mdx
+++ b/src/pages/further-reading/protocol-internals.mdx
@@ -1,7 +1,7 @@
 # Protocol Internals
 
 <Note type="danger">
-Documentation of certain protocol elements. Intended for **internal use only.**
+Documentation of certain protocol elements.
 </Note>
 
 ## Universal Link


### PR DESCRIPTION
clarifies purpose of protocol internals page