### PR TITLE
fix: try it sign in improvements

### DIFF
--- a/src/pages/try.tsx
+++ b/src/pages/try.tsx
@@ -249,6 +249,7 @@ const Try = (): JSX.Element => {
 		baseUrl.searchParams.append('response_type', 'code')
 		baseUrl.searchParams.append('scope', ['openid', ...signInScopes].join(' '))
 		baseUrl.searchParams.append('state', signInEnvironment)
+		baseUrl.searchParams.append('nonce', Math.random().toString(36).substring(2, 15))
 
 		baseUrl.searchParams.append(
 			'client_id',

--- a/src/pages/try.tsx
+++ b/src/pages/try.tsx
@@ -207,7 +207,7 @@ const Try = (): JSX.Element => {
 	}>({
 		mode: 'all',
 		defaultValues: {
-			signInScopes: [SignInScopes.OpenID],
+			signInScopes: [],
 			signInEnvironment: 'production',
 			testingEnvironment: 'production',
 			action: ("test-action-" + Math.random().toString(36).substring(2, 7)),


### PR DESCRIPTION
Ensures `openid` scope is not duplicated. Also includes a random `nonce` in the request (which is _not_ verified later) for compatibility with mobile-native flows.