### PR TITLE
feat: world chain guide redirect

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,6 +22,12 @@ const nextConfig = {
 	},
 	async redirects() {
 		return [
+            // remove when world chain docs are live 
+			{
+				source: '/world-chain',
+				destination: 'https://worldcoin.notion.site/World-Chain-Developer-Preview-Guide-23c94a67683f4e71986e5303ab88c9f3',
+				permanent: false,
+			},
 			{
 				source: '/apps',
 				destination: 'https://worldcoin.org/apps',


### PR DESCRIPTION
Redirects `/world-chain` to the notion guide for world chain. temporary, during developer preview, until world chain docs are live. future docs will live at this same path, preventing the need to update links everywhere