### PR TITLE
fix: removing links to stale on-chain verification repos and replacing them with latest

### DIFF
--- a/src/pages/id/on-chain.mdx
+++ b/src/pages/id/on-chain.mdx
@@ -4,7 +4,7 @@ import { Tag } from '@/components/Tag'
 
 World ID proofs can be fully verified on-chain. After all, the source of truth for the decentralized protocol is on-chain. To verify a World ID proof, your smart contract will embed a call to the `verifyProof` method of the World ID contract, and then execute the rest of its logic as usual.
 
-The smart contract starter kits ([Foundry](https://github.com/worldcoin/world-id-starter), [Hardhat](https://github.com/worldcoin/world-id-starter-hardhat)) and the [frontend & on-chain monorepo template](https://github.com/worldcoin/world-id-onchain-template) are great resources to help you get started with World ID. 
+The [smart contract starter kit](https://github.com/worldcoin/world-id-onchain-template) and the [frontend & on-chain monorepo template](https://github.com/worldcoin/world-id-onchain-template) are great resources to help you get started with World ID.
 Using one of these repositories is strongly recommended to get started with World ID on-chain.
 
 The following examples demonstrate the most common use case: verifying proofs from only Orb-verified users, for a single action, with a user's wallet address as the signal, while also enabling sybil-resistance. 


### PR DESCRIPTION
current docs link to repos that are no longer maintained