### PR TITLE
fix: deployment command

### DIFF
--- a/src/pages/world-chain/developers/deploy.mdx
+++ b/src/pages/world-chain/developers/deploy.mdx
@@ -100,7 +100,7 @@ group chat on [Telegram](https://t.me/worldcoindevelopers) or [Discord](https://
 Now that you have a wallet and you funded it with World Chain Sepolia ETH, you can deploy the `HelloWorldChain` contract to World Chain Sepolia using the following `forge create` command:
 
 ```bash {{title: "Deploy the contract"}}
-forge create src/HelloWorldChain.sol --rpc-url 	https://worldchain-sepolia.g.alchemy.com/public --private-key 0xcc1b30a6af68ea9a9917f1dda20c927704c5cdb2bbe0076901a8a0e40bf997c5
+forge create src/HelloWorldChain.sol:HelloWorldChain --rpc-url https://worldchain-sepolia.g.alchemy.com/public --private-key 0xcc1b30a6af68ea9a9917f1dda20c927704c5cdb2bbe0076901a8a0e40bf997c5
 ```
 
 Here we are using the `--rpc-url` flag to specify the RPC URL of the World Chain Sepolia network and the <br />`--private-key` flag to specify the private key of the wallet we generated earlier. 

--- a/src/pages/world-chain/developers/deploy.mdx
+++ b/src/pages/world-chain/developers/deploy.mdx
@@ -103,7 +103,8 @@ Now that you have a wallet and you funded it with World Chain Sepolia ETH, you c
 forge create src/HelloWorldChain.sol:HelloWorldChain --rpc-url https://worldchain-sepolia.g.alchemy.com/public --private-key 0xcc1b30a6af68ea9a9917f1dda20c927704c5cdb2bbe0076901a8a0e40bf997c5
 ```
 
-Here we are using the `--rpc-url` flag to specify the RPC URL of the World Chain Sepolia network and the <br />`--private-key` flag to specify the private key of the wallet we generated earlier. 
+Here, we are using the <path>:<contractname> format to specify the contract. This tells Foundry where to find the contract file (src/HelloWorldChain.sol) and which contract within the file (HelloWorldChain) to deploy.
+We also use the `--rpc-url` flag to specify the RPC URL of the World Chain Sepolia network and the <br />`--private-key` flag to specify the private key of the wallet we generated earlier. 
 On top of this we can also provide other flags like `-vvvvv` to get more verbose output from the deployment process, `--verify` to verify the contract on [Worldscan](https://worldscan.org) or [Blockscout](https://worldchain-sepolia.explorer.alchemy.com/) (alongside with an `--etherscan-api-key` flag) and 
 several other flags to toggle different features that you can find more about in the [Foundry documentation](https://book.getfoundry.sh/).
 


### PR DESCRIPTION
This pull request addresses an issue with the deployment command in the "Building on World Chain" section under "Deploy on World Chain." The original command was incorrect, resulting in an error when trying to deploy a smart contract using Foundry's `forge create`. This update fixes the command by specifying the contract in the `<path>:<contractname> `format.

**Changes Made**:
- Updated the deployment command to:
```
forge create src/HelloWorldChain.sol:HelloWorldChain --rpc-url https://worldchain-sepolia.g.alchemy.com/public --private-key 0xcc1b30a6af68ea9a9917f1dda20c927704c5cdb2bbe0076901a8a0e40bf997c5
```
- Added a brief explanation about the required format for specifying the contract source.

**Related Issue**:
This PR fixes #294 
