### PR TITLE
chore: Update world chain integrations

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -94,6 +94,8 @@
 		"zustand",
 		"Ingopedia",
 		"erigon",
+		"omnichain",
+		"CCIP",
 		"Permissioned"
 	]
 }

--- a/src/pages/world-chain/providers/bridges.mdx
+++ b/src/pages/world-chain/providers/bridges.mdx
@@ -40,6 +40,10 @@ It supports general asset transfers and custom cross-chain messaging, enabling u
 
 [LayerZero](https://layerzero.network/) is an omnichain interoperability protocol that enables seamless communication between different blockchains.
 
+## Chainlink CCIP
+
+[Chainlink CCIP](https://chain.link/cross-chain) is a blockchain interoperability protocol that enables developers to build secure applications that can transfer tokens, messages (data), or both tokens and messages across chains.
+
 # Liquidity Layers
 
 ## Cortex Protocol

--- a/src/pages/world-chain/providers/bridges.mdx
+++ b/src/pages/world-chain/providers/bridges.mdx
@@ -36,6 +36,10 @@ The next best method is to use the native Superchain bridge for which both Alche
 Hyperlane provides permissionless infrastructure for sending arbitrary data between blockchains, allowing developers to create applications that can be accessed from any connected chain.
 It supports general asset transfers and custom cross-chain messaging, enabling users to interact with assets and applications across different networks including World Chain.
 
+## LayerZero
+
+[LayerZero](https://layerzero.network/) is an omnichain interoperability protocol that enables seamless communication between different blockchains.
+
 # Liquidity Layers
 
 ## Cortex Protocol

--- a/src/pages/world-chain/providers/bridges.mdx
+++ b/src/pages/world-chain/providers/bridges.mdx
@@ -24,7 +24,6 @@ The next best method is to use the native Superchain bridge for which both Alche
 ## Synapse
 [Synapse](https://synapseprotocol.com/) is a cross-chain communication protocol that enables seamless asset transfers and messaging across different blockchain networks. It provides a secure and efficient infrastructure for interoperability, allowing users to move tokens and data between various chains without the need for centralized intermediaries.
 
-
 ## Across
 
 [Across](https://app.across.to/bridge?) is an intent-based cross-chain bridging protocol that allows users to transfer tokens between different blockchain networks, particularly focusing on Layer 2 solutions and Ethereum-compatible chains. 

--- a/src/pages/world-chain/providers/bridges.mdx
+++ b/src/pages/world-chain/providers/bridges.mdx
@@ -42,6 +42,7 @@ It supports general asset transfers and custom cross-chain messaging, enabling u
 ## Chainlink CCIP
 
 [Chainlink CCIP](https://chain.link/cross-chain) is a blockchain interoperability protocol that enables developers to build secure applications that can transfer tokens, messages (data), or both tokens and messages across chains.
+You can see World Chain-specific documentation for CCIP [here](https://docs.chain.link/ccip/directory/mainnet/chain/ethereum-mainnet-worldchain-1).
 
 # Liquidity Layers
 

--- a/src/pages/world-chain/providers/developer-tooling.mdx
+++ b/src/pages/world-chain/providers/developer-tooling.mdx
@@ -12,6 +12,13 @@ Alchemy provides a suite of data tools to make it easy to build on World Chain:
 - World Chain
 - World Chain Sepolia
 
+## Blocknative
+
+[Blocknative's Gas Price API](https://docs.blocknative.com/gas-prediction/gas-platform) predicts next-block gas prices.
+
+### Supported networks
+- World Chain
+
 ## QuickNode
 
 Access comprehensive developer tools built for World Chain:


### PR DESCRIPTION
adds Blocknative, LayerZero, and Chainlink CCIP to World Chain docs