### PR TITLE
feat: add alchemy account kit

### DIFF
--- a/src/pages/world-chain/providers/developer-tooling.mdx
+++ b/src/pages/world-chain/providers/developer-tooling.mdx
@@ -7,6 +7,7 @@ Alchemy provides a suite of data tools to make it easy to build on World Chain:
 -   [APIs](https://docs.alchemy.com/reference/token-api-quickstart) provide out-of-the-box solutions to retrieve fungible token balances, metadata, and historical transaction activity.
 -   [Webhooks](https://docs.alchemy.com/reference/notify-api-quickstart) allow you to configure real-time push notifications for on-chain activity.
 -   [Subgraphs](https://docs.alchemy.com/reference/subgraphs-quickstart) provide fast, reliable blockchain indexing and community APIs.
+-   [Account Kit](https://accountkit.alchemy.com/) provides smart wallets to grow your app. Securely onboard and activate users with no seed phrase or gas fees with easy-to-use, enterprise-grade wallets.
 
 ### Supported networks
 


### PR DESCRIPTION
Adds Alchemy's Account Kit to the dev tooling docs for World Chain.