### PR TITLE
Updating goldsky case and description

### DIFF
--- a/src/pages/world-chain/providers/data.mdx
+++ b/src/pages/world-chain/providers/data.mdx
@@ -49,15 +49,20 @@ For more data on [World](https://world.org/) and [World Chain](https://world.org
 
 - World Chain
 
-## GoldSky Subgraphs
+## Goldsky
 
-GoldSky Subgraphs is a data indexing service designed to simplify querying blockchain data. It provides developers with scalable, customizable subgraphs for
- efficiently indexing and retrieving on-chain data from various blockchain networks. GoldSky streamlines data access for decentralized applications (dApps),
- offering a user-friendly interface and advanced APIs that help developers query blockchain data faster and more accurately.
+Goldsky makes it easy to access real-time web3 data with little maintenance.
+
+[Goldsky Subgraphs](https://docs.goldsky.com/subgraphs/introduction) let you intelligently extract blockchain data with ease. Goldsky Subgraphs are fully backwards compatible, but in addition, offer:
+- a rewritten RPC layer, autoscaling query layer, and storage optimizations to improve reliability (99.9%+ uptime) and performance (up to 6x faster)
+- webhooks support out-the-box to enable notifications, messaging, and other push-based use cases
+
+[Goldsky Mirror](https://docs.goldsky.com/mirror/introduction) lets you replicate Subgraph data or chain-level streams directly to a data store of your choosing for highly flexible usage in your front-end or back-end. Out-of-the-box connectors for Postgres, ClickHouse, Elasticsearch, S3, Kafka, SQS, webhooks, and more mean that you can use the right stack for your use case.
 
 ### Supported networks
 
-- World Chain
+- World Chain  
+- World Chain Sepolia
 
 ## Alchemy Subgraphs
 


### PR DESCRIPTION
This PR fixes the case on Goldsky to remove the uppercase "S". It also updates the description to mention support for both mainnet and testnet, as well as support for both of Goldsky's indexing products: Subgraphs and Mirror.