### PR TITLE
docs: fix link to OIDC Explainer

### DIFF
--- a/src/pages/world-id/sign-in/getting-started.mdx
+++ b/src/pages/world-id/sign-in/getting-started.mdx
@@ -17,4 +17,4 @@ This template repository is a simple example of how to use Sign In with World ID
 pnpm i && pnpm dev
 ```
 
-To understand deeper our OIDC implementation check out [explainer page](/world-id/sign-in-with-world-id/oidc).
+To understand deeper our OIDC implementation check out [explainer page](/world-id/sign-in/oidc).


### PR DESCRIPTION
non-working link is here https://docs.world.org/world-id/sign-in/getting-started