### PR TITLE
chore: world chain info updates

### DIFF
--- a/src/pages/world-chain/developers/evm-equivalence.mdx
+++ b/src/pages/world-chain/developers/evm-equivalence.mdx
@@ -30,20 +30,20 @@ do differ.
     </tr>
     <tr>
       <td>Block gas limit</td>
-      <td>30,000,000</td>
-      <td>30,000,000</td>
-      <td>30,000,000</td>
+      <td>42,000,000</td>
+      <td>40,000,000</td>
+      <td>45,000,000</td>
     </tr>
     <tr>
       <td>Block gas target</td>
-      <td>10,000,000</td>
-      <td>5,000,000</td>
-      <td>15,000,000</td>
+      <td>21,000,000</td>
+      <td>20,000,000</td>
+      <td>22,500,000</td>
     </tr>
     <tr>
       <td>EIP-1559 elasticity multiplier</td>
-      <td>6</td>
-      <td>6</td>
+      <td>2</td>
+      <td>2</td>
       <td>2</td>
     </tr>
     <tr>
@@ -54,8 +54,8 @@ do differ.
     </tr>
     <tr>
     <td>Maximum base fee increase (per block)</td>
-    <td>0.8%</td>
-    <td>2%</td>
+    <td>0.4%</td>
+    <td>0.4%</td>
     <td>12.5%</td>
     </tr>
     <tr>

--- a/src/pages/world-chain/quick-start/info.mdx
+++ b/src/pages/world-chain/quick-start/info.mdx
@@ -135,7 +135,7 @@
     </tr>
    <tr>
       <td className="align-middle">Block Explorer</td>
-      <td className="align-middle">[worldchain-sepolia.explorer.alchemy.com](https://worldchain-sepolia.explorer.alchemy.com)</td>
+      <td className="align-middle">[sepolia.worldscan.org](https://sepolia.worldscan.org/)</td>
     </tr>
    <tr>
       <td className="align-middle">Status Page</td>

--- a/src/pages/world-chain/quick-start/info.mdx
+++ b/src/pages/world-chain/quick-start/info.mdx
@@ -142,12 +142,12 @@
       <td className="align-middle">[worldchain-sepolia-status.alchemy.com](https://worldchain-sepolia-status.alchemy.com)</td>
     </tr>
     <tr>
-      <td className="align-middle">Faucet</td>
-      <td className="align-middle">[worldchain-sepolia.g.alchemy.com/public](https://www.alchemy.com/faucets/world-chain-sepolia)</td>
-    </tr>
-   <tr>
       <td className="align-middle">RPC</td>
       <td className="align-middle">[worldchain-sepolia.g.alchemy.com/public](https://worldchain-sepolia.g.alchemy.com/public)</td>
+    </tr>
+    <tr>
+      <td className="align-middle">Faucet</td>
+      <td className="align-middle">[alchemy.com/faucets/world-chain-sepolia](https://www.alchemy.com/faucets/world-chain-sepolia)</td>
     </tr>
   </tbody>
 </table>

--- a/src/pages/world-chain/quick-start/info.mdx
+++ b/src/pages/world-chain/quick-start/info.mdx
@@ -25,11 +25,11 @@
     </tr>
     <tr>
       <td className="align-middle">Gas Limit</td>
-      <td className="align-middle">30M</td>
+      <td className="align-middle">42M</td>
     </tr>
     <tr>
       <td className="align-middle">Gas Target</td>
-      <td className="align-middle">15M</td>
+      <td className="align-middle">21M</td>
     </tr>
     <tr>
       <td className="align-middle">Block Time</td>

--- a/src/pages/world-chain/quick-start/info.mdx
+++ b/src/pages/world-chain/quick-start/info.mdx
@@ -1,6 +1,7 @@
 # Network Information
 
-## World Chain Mainnet 
+## World Chain Mainnet
+<Note type="info">World Chain Mainnet's per-block gas limit and target are regularly increased to accommodate the growing number of users and transactions. You can find the current gas limit [here](https://etherscan.io/address/0x6ab0777fD0e609CE58F939a7F70Fe41F5Aa6300A#readProxyContract#F18).</Note>
 <table>
   <tbody>
     <tr>


### PR DESCRIPTION
Updates general World Chain info to align with recent changes. Adds a disclaimer about regular gas limit/target increases with a link to see current values. Fixes broken links.