### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
         name: Typecheck
         runs-on: ubuntu-24.04
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v5
 
             - name: Set up Node 18
               uses: actions/setup-node@v3
@@ -51,7 +51,7 @@ jobs:
         name: Spellcheck
         runs-on: ubuntu-24.04
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v5
 
             - name: Set up Node 18
               uses: actions/setup-node@v3


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates.
Requires runner v2.327.1+. Workflows compile the same.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0